### PR TITLE
Fix for stalling uploads due to HTTPClient on Android

### DIFF
--- a/connect/src/main/java/org/jboss/capedwarf/connect/config/Configuration.java
+++ b/connect/src/main/java/org/jboss/capedwarf/connect/config/Configuration.java
@@ -36,6 +36,10 @@ public abstract class Configuration<T> {
 
     private String httpEndpoint;
     private String sslEndpoint;
+    private int soTimeout = 30 * (int) Constants.SECOND;
+    private boolean expectContinue = true;
+    private boolean staleCheckingEnabled;
+    private int socketBufferSize = 8192;
 
     public synchronized static <T> Configuration<T> getInstance() {
         if (instance == null)
@@ -250,5 +254,37 @@ public abstract class Configuration<T> {
 
     public void setSslFactory(SocketFactory sslFactory) {
         this.sslFactory = sslFactory;
+    }
+
+    public int getSoTimeout() {
+        return soTimeout;
+    }
+
+    public void setSoTimeout(int soTimeout) {
+        this.soTimeout = soTimeout;
+    }
+
+    public boolean isExpectContinue() {
+        return expectContinue;
+    }
+
+    public void setExpectContinue(boolean expectContinue) {
+        this.expectContinue = expectContinue;
+    }
+
+    public boolean isStaleCheckingEnabled() {
+        return staleCheckingEnabled;
+    }
+
+    public void setStaleCheckingEnabled(boolean staleCheckingEnabled) {
+        this.staleCheckingEnabled = staleCheckingEnabled;
+    }
+
+    public int getSocketBufferSize() {
+        return socketBufferSize;
+    }
+
+    public void setSocketBufferSize(int socketBufferSize) {
+        this.socketBufferSize = socketBufferSize;
     }
 }

--- a/connect/src/main/java/org/jboss/capedwarf/connect/server/ServerProxyHandler.java
+++ b/connect/src/main/java/org/jboss/capedwarf/connect/server/ServerProxyHandler.java
@@ -87,6 +87,12 @@ public class ServerProxyHandler implements ServerProxyInvocationHandler {
             HttpConnectionParams.setConnectionTimeout(params, config.getConnectionTimeout());
             HttpProtocolParams.setVersion(params, config.getHttpVersion());
             HttpProtocolParams.setContentCharset(params, config.getContentCharset());
+            HttpProtocolParams.setUseExpectContinue(params, config.isExpectContinue());
+            HttpConnectionParams.setStaleCheckingEnabled(params, config.isStaleCheckingEnabled());
+            HttpConnectionParams.setConnectionTimeout(params, config.getConnectionTimeout());
+            HttpConnectionParams.setSoTimeout(params, config.getSoTimeout());
+            HttpConnectionParams.setSocketBufferSize(params, config.getSocketBufferSize());
+
 
             // Create and initialize scheme registry
             SchemeRegistry schemeRegistry = new SchemeRegistry();


### PR DESCRIPTION
Looks like default settings in combination with connection object sharing don't work well.
This may make it work better.
